### PR TITLE
[SofaPython3] The coder returning "values" out of Basedata is broken

### DIFF
--- a/Plugin/src/SofaPython3/PythonFactory.cpp
+++ b/Plugin/src/SofaPython3/PythonFactory.cpp
@@ -179,7 +179,12 @@ py::object PythonFactory::valueToPython_ro(sofa::core::objectmodel::BaseData* da
     /// we can expose the field as a numpy.array (no copy)
     if(nfo.Container() && nfo.SimpleLayout())
     {
-        return getPythonArrayFor(data);
+        auto capsule = py::capsule(new Base::SPtr(data->getOwner()));
+        py::buffer_info ninfo = toBufferInfo(*data);
+        py::array a(pybind11::dtype(ninfo), ninfo.shape,
+                    ninfo.strides, ninfo.ptr, capsule);
+        a.attr("flags").attr("writeable") = false;
+        return std::move(a);
     }
 
     /// If this is not the case we return the converted datas (copy)


### PR DESCRIPTION
There was two problem:
- the array values should always be returned as non writable numpy array otherwise this breaks the consistency of the
  data notification mecanism.
- the arrays were stored in a cache, to accelerate things, but there is bug in the cache logics, resulting in hard to
  spot side effect...so now it is not using cache anymore.

EDIT: the bug was pointed by @StephaneCotin on gitter.