### PR TITLE
FIX getRoot()

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Node.cpp
@@ -432,6 +432,15 @@ py::object getMechanicalMapping(Node *self)
     return py::none();
 }
 
+py::object getRoot(Node* self)
+{
+    auto root = self->getRoot();
+    if (root) {
+        return PythonFactory::toPython(root);
+    }
+    return py::none();
+}
+
 void sendEvent(Node* self, py::object pyUserData, char* eventName)
 {
     sofapython3::PythonScriptEvent event(self, eventName, pyUserData);
@@ -476,7 +485,7 @@ void moduleAddNode(py::module &m) {
     p.def("getChild", &getChild, sofapython3::doc::sofa::core::Node::getChild);
     p.def("removeChild", &removeChild, sofapython3::doc::sofa::core::Node::removeChild);
     p.def("removeChild", &removeChildByName, sofapython3::doc::sofa::core::Node::removeChildWithName);
-    p.def("getRoot", &Node::getRoot, sofapython3::doc::sofa::core::Node::getRoot);
+    p.def("getRoot", &getRoot, sofapython3::doc::sofa::core::Node::getRoot);
     p.def("getPathName", &Node::getPathName, sofapython3::doc::sofa::core::Node::getPathName);
     p.def("getLinkPath", &getLinkPath, sofapython3::doc::sofa::core::Node::getLinkPath);
     p.def_property_readonly("children", &property_children, sofapython3::doc::sofa::core::Node::children);

--- a/bindings/Sofa/tests/Simulation/Node.py
+++ b/bindings/Sofa/tests/Simulation/Node.py
@@ -158,6 +158,12 @@ class Test(unittest.TestCase):
             self.assertEqual(root["node1.node2.object2.name"], object2.name)
 
             self.assertEqual(root["node1.node2.object2.name"], root.node1.node2.object2.name)
+
+	def test_getRoot(self):
+            root = Sofa.Core.Node("root")
+            node = root.addChild("node")
+            self.assertEqual(node.getRoot(), root)
+
         def test_getRootPath(self):
             root = Sofa.Core.Node("root")
             node = root.addChild("node")


### PR DESCRIPTION
Binding was not wrapping BaseNode* into a Sofa.Core.Node()