### PR TITLE
FIX: Downcast of Data

### DIFF
--- a/Plugin/src/SofaPython3/PythonFactory.cpp
+++ b/Plugin/src/SofaPython3/PythonFactory.cpp
@@ -162,10 +162,10 @@ py::object PythonFactory::toPython(const sofa::core::objectmodel::BaseData* data
 
 py::object PythonFactory::toPython(sofa::core::objectmodel::BaseData* data)
 {
-    auto metaclass = data->getClass();
+    auto type = data->getValueTypeInfo()->name();
 
     /// Let's first search if there is a casting function for the given type.
-    auto kv = s_dataDowncastingFct.find(metaclass->templateName);
+    auto kv = s_dataDowncastingFct.find(type);
     if( kv != s_dataDowncastingFct.end())
     {
         return kv->second(data);
@@ -173,21 +173,20 @@ py::object PythonFactory::toPython(sofa::core::objectmodel::BaseData* data)
 
     const sofa::defaulttype::AbstractTypeInfo& nfo { *(data->getValueTypeInfo()) };
 
-
     if(nfo.Container() && nfo.SimpleLayout())
     {
-        s_dataDowncastingFct[metaclass->templateName] = s_dataDowncastingFct["DataContainer"];
-        return s_dataDowncastingFct[metaclass->templateName](data);
+        s_dataDowncastingFct[type] = s_dataDowncastingFct["DataContainer"];
+        return s_dataDowncastingFct[type](data);
     }
     if(nfo.Container() && nfo.Text())
     {
-        s_dataDowncastingFct[metaclass->templateName] = s_dataDowncastingFct["DataVectorString"];
-        return s_dataDowncastingFct[metaclass->templateName](data);
+        s_dataDowncastingFct[type] = s_dataDowncastingFct["DataVectorString"];
+        return s_dataDowncastingFct[type](data);
     }
     if(nfo.Text())
     {
-        s_dataDowncastingFct[metaclass->templateName] = s_dataDowncastingFct["DataString"];
-        return s_dataDowncastingFct[metaclass->templateName](data);
+        s_dataDowncastingFct[type] = s_dataDowncastingFct["DataString"];
+        return s_dataDowncastingFct[type](data);
     }
     return py::cast(data);
 }


### PR DESCRIPTION
The toPython method in PythonFactory has 2 purposes:

1. by looking into the Data's TypeInfo, determining which kind of data it should return: DataContainer / DataVectorString, DataString or a generic Data wrapper
2. store the kind of data to return in a map using as key the template type of that Data, in order to not have to figure out the wrapper to return next time a similar data is to be returned

the key used for this map was BaseData::GetClass()->templateName, which happens to always be an empty string (dunno what this variable is actually supposed to store, but in the case of Data, it's alwas an empty string for me....) Thus, if a data is detected to be a "DataString" for instance, this type will be stored in a map, under the key "" (emptyString), and the next time a data must be retrieved, let's say a vector<Vec3d>, the code will look at its templateName ("" emptyString), look into the downcast map for an existing type for this key, and return a DataString instead of a DataContainer...

This PR replaces the use of tempalteName as a key for the map, with the data's typeInfo->name(), thus effectively storing the right key in the map.