### PR TITLE
[cmake] Add XCode framework to RPath on MacOS

### DIFF
--- a/CMake/SofaPython3Tools.cmake
+++ b/CMake/SofaPython3Tools.cmake
@@ -149,6 +149,14 @@ function(SP3_add_python_module)
             INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${LIBRARY_OUTPUT_DIRECTORY}"
     )
 
+    if (APPLE)
+        set_target_properties(
+            ${PROJECT_NAME}
+            PROPERTIES
+            INSTALL_NAME_DIR "@rpath/${SP3_PYTHON_PACKAGES_DIRECTORY}/${DESTINATION}"
+        )
+    endif()
+
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
         set_target_properties(
             ${A_TARGET}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,22 @@ message("-- Python user site: ${PYTHON_USER_SITE}")
 message("-- pybind11 version: ${pybind11_VERSION}")
 message("-- pybind11 config: ${pybind11_CONFIG}")
 
+# When using python3 from XCode on MacOS, the RPath is wrongly set to XCode frameworks directory:
+#   LC_LOAD_DYLIB   @rpath/Python3.framework/Versions/3.7/Python3
+#   LC_RPATH        /Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.7/lib
+# Hence LC_RPATH/LC_LOAD_DYLIB does not exists.
+# Until this is fixed (not sure if it comes from pybind11, cmake or XCode), we can add another path to RPATH:
+#   LC_LOAD_DYLIB   @rpath/Python3.framework/Versions/3.7/Python3
+#   LC_RPATH        /Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.7/lib
+#                   /Applications/Xcode.app/Contents/Developer/Library/Frameworks  <----- ADDED
+# And now one combination of  LC_RPATH/LC_LOAD_DYLIB will be valid.
+# This should't change anything for those that use other python libs than XCode (homebrew for example) since the
+# LC_LOAD_DYLIB from XCode is quite unique.
+if (APPLE)
+    set(CMAKE_INSTALL_RPATH "/Applications/Xcode.app/Contents/Developer/Library/Frameworks")
+    set(CMAKE_BUILD_RPATH "/Applications/Xcode.app/Contents/Developer/Library/Frameworks")
+endif()
+
 add_subdirectory(Plugin)
 add_subdirectory(bindings)
 add_subdirectory(examples)


### PR DESCRIPTION
For some reason, when using python 3 libs from XCode, the RPATH set by cmake wasn't matching the relative path of the cpython library. This change simply adds the standard XCode framework path to the RPath for both build and install binaries.