### PR TITLE
ImportPlugin now takes a pointer to the globals

### DIFF
--- a/Plugin/src/SofaPython3/PythonEnvironment.cpp
+++ b/Plugin/src/SofaPython3/PythonEnvironment.cpp
@@ -141,17 +141,20 @@ PythonEnvironmentData* PythonEnvironment::getStaticData()
     return m_staticdata;
 }
 
-SOFAPYTHON3_API py::module PythonEnvironment::importFromFile(const std::string& module, const std::string& path, py::object globals)
+SOFAPYTHON3_API py::module PythonEnvironment::importFromFile(const std::string& module, const std::string& path, py::object* globals)
 {
     PythonEnvironment::gil lock;
     py::dict locals;
     locals["module_name"] = py::cast(module); // have to cast the std::string first
     locals["path"]        = py::cast(path);
     msg_info("SofaPython3") << "Importing module: " << path ;
+    py::object globs = py::globals();
+    if (globals == nullptr)
+        globals = &globs;
     py::eval<py::eval_statements>(            // tell eval we're passing multiple statements
                                               "import imp\n"
                                               "new_module = imp.load_module(module_name, open(path), path, ('py', 'U', imp.PY_SOURCE))\n",
-                                              globals,
+                                              *globals,
                                               locals);
     py::module m =  py::cast<py::module>(locals["new_module"]);
     return m;

--- a/Plugin/src/SofaPython3/PythonEnvironment.cpp
+++ b/Plugin/src/SofaPython3/PythonEnvironment.cpp
@@ -141,7 +141,7 @@ PythonEnvironmentData* PythonEnvironment::getStaticData()
     return m_staticdata;
 }
 
-SOFAPYTHON3_API py::module PythonEnvironment::importFromFile(const std::string& module, const std::string& path, py::object& globals)
+SOFAPYTHON3_API py::module PythonEnvironment::importFromFile(const std::string& module, const std::string& path, py::object globals)
 {
     PythonEnvironment::gil lock;
     py::dict locals;

--- a/Plugin/src/SofaPython3/PythonEnvironment.h
+++ b/Plugin/src/SofaPython3/PythonEnvironment.h
@@ -84,7 +84,7 @@ public:
 
     static py::module importFromFile(const std::string& module,
                                      const std::string& path,
-                                     py::object globals = py::object());
+                                     py::object* globals = nullptr);
 
     /// Add a path to sys.path, the list of search path for Python modules.
     static void addPythonModulePath(const std::string& path);

--- a/Plugin/src/SofaPython3/PythonEnvironment.h
+++ b/Plugin/src/SofaPython3/PythonEnvironment.h
@@ -84,7 +84,7 @@ public:
 
     static py::module importFromFile(const std::string& module,
                                      const std::string& path,
-                                     py::object& globals);
+                                     py::object globals = py::object());
 
     /// Add a path to sys.path, the list of search path for Python modules.
     static void addPythonModulePath(const std::string& path);

--- a/Plugin/src/SofaPython3/PythonTest.cpp
+++ b/Plugin/src/SofaPython3/PythonTest.cpp
@@ -167,7 +167,7 @@ void PythonTest::run( const PythonTestData& data )
             SetDirectory localDir(filename);
             std::string basename = SetDirectory::GetFileNameWithoutExtension(SetDirectory::GetFileName(filename).c_str());
             module = PythonEnvironment::importFromFile(basename, SetDirectory::GetFileName(filename),
-                                                       globals);
+                                                       &globals);
 
             py::object testSuite = getTestSuite(unittest, module, data.arguments);
             py::list testSuiteList = py::cast<py::list>(testSuite);
@@ -216,7 +216,7 @@ void PythonTestList::addTest( const std::string& filename,
         SetDirectory localDir(pathC);
         std::string basename = SetDirectory::GetFileNameWithoutExtension(SetDirectory::GetFileName(filenameC).c_str());
         module = PythonEnvironment::importFromFile(basename, SetDirectory::GetFileName(filenameC),
-                                                   globals);
+                                                   &globals);
         std::list<std::string> testNames;
         py::list testSuite = getTestSuite(unittest, module, arguments);
         if(!testSuite.size())

--- a/Plugin/src/SofaPython3/SceneLoaderPY3.cpp
+++ b/Plugin/src/SofaPython3/SceneLoaderPY3.cpp
@@ -123,7 +123,7 @@ void SceneLoaderPY3::loadSceneWithArguments(const char *filename,
 
         SetDirectory localDir(filename);
         std::string basename = SetDirectory::GetFileNameWithoutExtension(SetDirectory::GetFileName(filename).c_str());
-        module = PythonEnvironment::importFromFile(basename, SetDirectory::GetFileName(filename), globals);
+        module = PythonEnvironment::importFromFile(basename, SetDirectory::GetFileName(filename), &globals);
 
         if(!py::hasattr(module, "createScene"))
         {


### PR DESCRIPTION
This way we can use default py::globals() if necessary without having to instantiate globals before calling the method