### PR TITLE
ADD: sized-deallocation on test targets

### DIFF
--- a/CMake/SofaPython3Tools.cmake
+++ b/CMake/SofaPython3Tools.cmake
@@ -110,7 +110,7 @@ function(SP3_add_python_module)
     )
 
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-        target_compile_options(${A_TARGET} PRIVATE -fsized-deallocation)
+        target_compile_options(${A_TARGET} PUBLIC -fsized-deallocation)
     endif()
 
     if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/CMake/SofaPython3Tools.cmake
+++ b/CMake/SofaPython3Tools.cmake
@@ -109,6 +109,10 @@ function(SP3_add_python_module)
         PUBLIC $<INSTALL_INTERFACE:include>
     )
 
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        target_compile_options(${A_TARGET} PRIVATE -fsized-deallocation)
+    endif()
+
     if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
         target_compile_options(${A_TARGET} PRIVATE -Dregister=)
     endif()

--- a/CMake/SofaPython3Tools.cmake
+++ b/CMake/SofaPython3Tools.cmake
@@ -109,10 +109,6 @@ function(SP3_add_python_module)
         PUBLIC $<INSTALL_INTERFACE:include>
     )
 
-    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-        target_compile_options(${A_TARGET} PRIVATE -fsized-deallocation)
-    endif()
-
     if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
         target_compile_options(${A_TARGET} PRIVATE -Dregister=)
     endif()

--- a/Plugin/CMakeLists.txt
+++ b/Plugin/CMakeLists.txt
@@ -59,8 +59,7 @@ set_target_properties(
 )
 
 if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-    # Sized deallocaion is not enabled by default under clang after c++14
-    set(CMAKE_CXX_FLAGS "-fsized-deallocation")
+    target_compile_options(${PROJECT_NAME} PUBLIC "-fsized-deallocation")
 endif ()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)

--- a/Plugin/CMakeLists.txt
+++ b/Plugin/CMakeLists.txt
@@ -59,6 +59,7 @@ set_target_properties(
 )
 
 if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    # Sized deallocaion is not enabled by default under clang after c++14
     target_compile_options(${PROJECT_NAME} PUBLIC "-fsized-deallocation")
 endif ()
 


### PR DESCRIPTION
The sized-deallocation flag was:
- set in PRIVATE of the target in the binding modules
- set in the CXX_FLAGS of the Plugin
- Not set in the tests, which led to compile errors on some setups.

This PR sets the flag in PUBLIC in the Plugin, which propagates to the bindings and the tests.
There should be no side-effects with having it public, except for the fact that you won't have to add it again manually in your plugins that depend on SP3 (such as SofaQtQuickGUI)