### PR TITLE
FIX compilation of Bindings.Sofa.Simulation

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Simulation/CMakeLists.txt
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Simulation/CMakeLists.txt
@@ -18,5 +18,5 @@ SP3_add_python_module(
         MODULE_NAME  Simulation
         SOURCES      ${SOURCE_FILES}
         HEADERS      ${HEADER_FILES}
-        DEPENDS      SofaCore SofaSimulationCore SofaSimulationGraph SofaBaseVisual
+        DEPENDS      SofaCore SofaSimulationCore SofaSimulationGraph SofaBaseVisual SofaPython3::Plugin
 )


### PR DESCRIPTION
missing SofaPython3::Plugin target in Dependencies

Any idea how this could ever compile on my machine? Another problem that's been reported to me but that I didn't experience myself