### PR TITLE
[SofaPython3] Restore the plugins automatic loading of python libraries.

### DIFF
--- a/Plugin/src/SofaPython3/PythonEnvironment.h
+++ b/Plugin/src/SofaPython3/PythonEnvironment.h
@@ -94,7 +94,8 @@ public:
 
     /// Add all the directories matching <pluginsDirectory>/*/python to sys.path
     /// NB: can also be used for projects <projectDirectory>/*/python
-    static void addPythonModulePathsForPlugins(const std::string& pluginsDirectory);
+    static void addPythonModulePathsForPlugins(const std::string& pluginsDirectory);    
+    static void addPythonModulePathsForPluginsByName(const std::string& pluginName);
 
     /// set the content of sys.argv.
     static void setArguments(const std::string& filename,


### PR DESCRIPTION
When we load a c++ plugin it may be packaged with additional python files
(examples, libraries, or per plugin binding). These files should be visible from the python environment.

This is done by the added code that scans the plugin's directory and register any path matching the following patterns:
pluginName/lib/site-packages
pluginName/lib/python3/site-packages

This behavior was the implemented in the previous version of SofaPython and proved to be useful. 