### PR TITLE
Change the SP3_PYTHON_PACKAGES_DIRECTORY cmake variable type to STRING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,8 +72,9 @@ find_package(pybind11 2.3 CONFIG QUIET REQUIRED)
 
 set(SP3_PYTHON_PACKAGES_DIRECTORY
     "site-packages"
-    CACHE PATH
-    "Path to the directory where the python packages will be built and installed. (default to site-packages)"
+    CACHE STRING
+    "Directory name where the python packages will be built and installed.
+    This will be prepend to LIBRARY_OUTPUT_DIRECTORY (default to site-packages)"
 )
 
 # Get the Python's user site packages directory, or FASLE if not found


### PR DESCRIPTION
The SP3_PYTHON_PACKAGES_DIRECTORY is set to 'site-packages' by default, and is prepend to the `build/lib` or `install/lib` to get the directoy path where python packages should be build or installed, respectively.

It was reported that having this cmake variable as a PATH type would sometime mess with the resulting absolute path, as we are concatenating two PATHs together.

This PR simply changes the type of  SP3_PYTHON_PACKAGES_DIRECTORY to a STRING cached variable.