### PR TITLE
[Binding.Sofa.Core] FIX Link bindings

### DIFF
--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_Base.cpp
@@ -417,7 +417,7 @@ void moduleAddBase(py::module &m)
 
     base.def("getDataFields", &BindingBase::getDataFields, pybind11::return_value_policy::reference, sofapython3::doc::base::getDataFields);
     base.def("findLink", &Base::findLink, pybind11::return_value_policy::reference, sofapython3::doc::base::findLink);
-    base.def("getLinks", &Base::getLinks, pybind11::return_value_policy::reference, sofapython3::doc::base::getLinks);
+    base.def("getLinks", &BindingBase::getLinks, pybind11::return_value_policy::reference, sofapython3::doc::base::getLinks);
     base.def("addData", &BindingBase::addData, "name"_a, "value"_a = py::none(), "default"_a = py::none(), "help"_a = "", "group"_a = "", "type"_a = "", sofapython3::doc::base::addData);
     base.def("addData", &BindingBase::addDataFromData, sofapython3::doc::base::addDataInitialized);
     base.def("__getattr__", &BindingBase::__getattr__);

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseLink.cpp
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseLink.cpp
@@ -25,8 +25,21 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
     - thierry.gaugry@inria.fr
 ********************************************************************/
 
+
+#include <sofa/core/objectmodel/BaseLink.h>
+using sofa::core::objectmodel::BaseLink;
+
+#include <sofa/core/objectmodel/BaseObject.h>
+using  sofa::core::objectmodel::BaseObject;
+
+#include <sofa/core/objectmodel/BaseNode.h>
+using  sofa::core::objectmodel::BaseNode;
+
+#include "Binding_Base.h"
 #include "Binding_BaseLink.h"
 #include "Binding_BaseLink_doc.h"
+#include <SofaPython3/DataHelper.h>
+#include <SofaPython3/PythonFactory.h>
 
 namespace sofapython3
 {
@@ -40,9 +53,21 @@ void setHelp(BaseLink* self, const std::string value)
     self->setHelp(S);
 }
 
+py::object getLinkedBase(BaseLink& self, unsigned index = 0)
+{
+    if (self.getLinkedBase(index))
+        return PythonFactory::toPython(self.getLinkedBase(index));
+    return py::none();
+}
+
+py::object getOwnerBase(BaseLink& self)
+{
+    return PythonFactory::toPython(self.getOwnerBase());
+}
+
 void moduleAddBaseLink(py::module& m)
 {
-    py::class_<BaseLink> link(m, "Link", sofapython3::doc::baseLink::baseLinkClass);
+    py::class_<BaseLink, std::unique_ptr<sofa::core::objectmodel::BaseLink, pybind11::nodelete>> link(m, "Link", sofapython3::doc::baseLink::baseLinkClass);
     link.def("getName", &BaseLink::getName, sofapython3::doc::baseLink::getName);
     link.def("setName", &BaseLink::setName, sofapython3::doc::baseLink::setName);
     link.def("isMultiLink", &BaseLink::isMultiLink, sofapython3::doc::baseLink::isMultiLink);
@@ -58,12 +83,12 @@ void moduleAddBaseLink(py::module& m)
     link.def("setHelp", setHelp, sofapython3::doc::baseLink::setHelp);
 
     link.def("getOwnerData", &BaseLink::getOwnerData, sofapython3::doc::baseLink::getOwnerData);
-    link.def("getOwnerBase", &BaseLink::getOwnerBase, sofapython3::doc::baseLink::getOwnerBase);
+    link.def("getOwnerBase", getOwnerBase, sofapython3::doc::baseLink::getOwnerBase);
 
     link.def("getLinkedData", &BaseLink::getLinkedData, sofapython3::doc::baseLink::getLinkedData);
-    link.def("getLinkedBase", &BaseLink::getLinkedBase, sofapython3::doc::baseLink::getLinkedBase);
+    link.def("getLinkedBase", getLinkedBase, "index"_a = 0, sofapython3::doc::baseLink::getLinkedBase);
 
-    link.def("getLinkedPath", &BaseLink::getLinkedPath, sofapython3::doc::baseLink::getLinkedPath);
+    link.def("getLinkedPath", &BaseLink::getLinkedPath, "index"_a = 0, sofapython3::doc::baseLink::getLinkedPath);
     link.def("read", &BaseLink::read, sofapython3::doc::baseLink::read);
 
 }

--- a/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseLink.h
+++ b/bindings/Sofa/src/SofaPython3/Sofa/Core/Binding_BaseLink.h
@@ -28,11 +28,7 @@ along with sofaqtquick. If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 #include <sofa/core/objectmodel/BaseLink.h>
-#include "Binding_Base.h"
-using sofa::core::objectmodel::BaseLink;
-#include <pybind11/pybind11.h>
-
-namespace py { using namespace pybind11; }
+#include <SofaPython3/DataHelper.h>
 
 namespace sofapython3
 {


### PR DESCRIPTION
A function was implemented for getLinks, to retrieve a py::list from the binding, but it wasn't used. Also, the getLinkedBase method binding wasn't working